### PR TITLE
OS-specific packages correction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,17 @@ depend, specified as though they were created using the following `conda` comman
 
 ```
 source activate example-environment
-conda env export > environment.yml
+conda env export --no-builds -f environment.yml
 ```
 
 Note that the only libraries available to you will be the ones specified in
-the `environment.yml`, so be sure to include everything that you need!
+the `environment.yml`, so be sure to include everything that you need! 
+
+Also note that conda will possibly try to include OS-specific packages in `environment.yml`, so you
+may have to manually prune `environment.yml` to get rid of these packages. Confirmed Mac-OSX-specific
+packages that should be removed are:
+
+* libcxxabi=4.0.1
+* appnope=0.1.0
+* libgfortran=3.0.1
+* libcxx=4.0.1


### PR DESCRIPTION
Updated README to recommend default `conda env export` command include `--no-builds` and recommend OSX-specific packages to manually prune from environment.yml file to avoid Binder build failure.