### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,17 @@ The `environment.yml` file should list all Python libraries on which your notebo
 depend, specified as though they were created using the following `conda` commands:
 
 ```
-source activate example-environment
-conda env export --no-builds -f environment.yml
+conda activate example-environment
+conda env export --from-history -f environment.yml
 ```
 
 Note that the only libraries available to you will be the ones specified in
 the `environment.yml`, so be sure to include everything that you need! 
 
-Also note that conda will possibly try to include OS-specific packages in `environment.yml`, so you
-may have to manually prune `environment.yml` to get rid of these packages. Confirmed Mac-OSX-specific
-packages that should be removed are:
+Also note that if you skip the `--from-history`, conda may include OS-specific
+packages in `environment.yml`, which you would have to manually prune from
+`environment.yml`.  For example, confirmed macOS-specific packages that should
+be removed are:
 
 * libcxxabi=4.0.1
 * appnope=0.1.0


### PR DESCRIPTION
Two small — though important — changes

  1. Since [the release of conda 4.6](https://www.anaconda.com/blog/conda-4-6-release), the [recommended way to activate a conda env](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) is to use `conda activate <myenv>`.
  2. The [conda docs say](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#exporting-an-environment-file-across-platforms) that the correct way to export an env is to use the `--from-history` flag.  This only includes packages that you’ve explicitly asked for, and only "pins" versions when you asked to do so.  If you use this flag, the "macOS-specific" packages probably won't appear.

I'm actually of the opinion that the list of macOS-specific packages should be removed, but I'll leave them here because other people don't seem to agree — though in any case, I don't see why those packages' versions should be relevant.  See also #11.